### PR TITLE
Fix platform detection in package download script

### DIFF
--- a/tol-master/building/Linux/download_default_packages.sh
+++ b/tol-master/building/Linux/download_default_packages.sh
@@ -5,7 +5,7 @@
 #************************************************************
 
 MACHINE_TYPE=`uname -m`
-if [ ${MACHINE_TYPE} = 'x86_64' ]; then
+if [ "${MACHINE_TYPE}" = 'x86_64' ]; then
   tol_platform=Linux64GNU
 else
   tol_platform=Linux32GNU

--- a/tol-master/building/Linux/download_default_packages.sh
+++ b/tol-master/building/Linux/download_default_packages.sh
@@ -6,9 +6,9 @@
 
 MACHINE_TYPE=`uname -m`
 if [ ${MACHINE_TYPE} = 'x86_64' ]; then
-  tol_platform=Linux32GNU
-else
   tol_platform=Linux64GNU
+else
+  tol_platform=Linux32GNU
 fi
 
 echo "Download default packages for $tol_platform"


### PR DESCRIPTION
## Summary
- fix Linux platform detection in `download_default_packages.sh`

## Testing
- `bash tol-master/building/Linux/download_default_packages.sh 2>&1 | head -n 3`


------
https://chatgpt.com/codex/tasks/task_b_68475e99df64832381b241742836bd9c

## Summary by Sourcery

Fix the platform detection logic in the Linux package download script to assign the correct 32-bit or 64-bit label based on machine architecture

Bug Fixes:
- Correct assignment of `tol_platform` for x86_64 machines to `Linux64GNU` instead of `Linux32GNU`
- Swap default platform labels to ensure non-x86_64 architectures are labeled `Linux32GNU`