### PR TITLE
Fix invocation comment

### DIFF
--- a/tol-master/building/Linux/build_installer.sh
+++ b/tol-master/building/Linux/build_installer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #************************************************************
 # La llamada al script no recibe argumentos:
-#   ./build_instaler.sh
+#   ./build_installer.sh
 #************************************************************
 # Durante el proceso se pregunta por cada una de las etapas.
 #************************************************************


### PR DESCRIPTION
## Summary
- correct script invocation example in `build_installer.sh`

## Testing
- `grep -n "build_installer" tol-master/building/Linux/build_installer.sh`


------
https://chatgpt.com/codex/tasks/task_b_68475ea5e65083239e936cb305fdd40d