### PR TITLE
Fix CholeskiInverse test

### DIFF
--- a/tol-master/tol/btol/matrix_type/tests/CholeskiInverse.tol
+++ b/tol-master/tol/btol/matrix_type/tests/CholeskiInverse.tol
@@ -24,7 +24,8 @@ Real {
    ));
 
   Matrix A_ = CholeskiInverse(A);
-  Real ok = If(U==(Matrix A*A_),1,0);
+  Real diff = MatMax(Abs(A*A_ - U));
+  Real ok = If(diff < 1e-9,1,0);
   // Show Results
   WriteLn(If(ok,"OK","ERROR"));
   ok


### PR DESCRIPTION
## Summary
- use tolerance when comparing CholeskiInverse result

## Testing
- `python3 scripts/identify_pure_tol_files.py`

------
https://chatgpt.com/codex/tasks/task_b_68475eb00284832383a6609ebb8df37f

## Summary by Sourcery

Fix the CholeskiInverse test to use tolerance-based comparisons for numerical results.

Bug Fixes:
- Apply a numeric tolerance when comparing CholeskiInverse outputs to avoid strict equality failures.

Tests:
- Update the CholeskiInverse test to use tolerance in its assertions.