### PR TITLE
Add API reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ tolcon
 - [TOL User Manual](tol-master/doc/general/TOL%20User%20Manual.pdf)
 - [Basic TOL Manual (Spanish)](tol-master/doc/general/Manual%20basico%20de%20TOL.pdf)
 - API documentation available in `tol-master/doc/`
+- Additional module references in `docs/api/`
 
 ## Contributing
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,18 @@
+# TOL API Reference
+
+This directory contains reference guides for key modules in the TOL ecosystem. Each module has its own Markdown file documenting its public API, data types, integration notes, and performance considerations.
+
+Available modules:
+
+- [Mathematical Operations](mathematical_operations.md)
+- [Time-Series Analysis](time_series_analysis.md)
+- [Statistical Analysis](statistical_analysis.md)
+- [Core Data Types](core_data_types.md)
+- [Database Connectivity](database_connectivity.md)
+- [File and System Integration](file_system_integration.md)
+- [Core Plotting Functions](plotting_functions.md)
+- [GUI Visualization](gui_visualization.md)
+- [GUI Application](gui_application.md)
+- [Java API](java_api.md)
+- [Communication and Remote Access](communication_remote.md)
+- [Standard Library](standard_library.md)

--- a/docs/api/communication_remote.md
+++ b/docs/api/communication_remote.md
@@ -1,0 +1,26 @@
+# Communication and Remote Access Module (`tolcomm`)
+
+## Module Overview
+Provides client and server components for executing TOL code across a network. Supports custom protocols and remote procedure calls.
+
+## Core Functions/Classes
+### `tolclient::connect(Text host, Integer port) -> Handle`
+Opens a client connection to a remote TOL server.
+
+### `tolclient::eval(Handle h, Text code) -> Text`
+Sends code to be executed on the server and returns the textual result.
+
+### `tolserver::start(Integer port)`
+Starts a server listening for remote requests.
+
+### `tolserver::stop()`
+Stops the server.
+
+## Data Types
+Handles are opaque references to network connections.
+
+## Integration Notes
+Used to build distributed applications or to run heavy computations on separate machines. Can be combined with the Java API for remote execution from Java clients.
+
+## Performance Considerations
+Network latency dominates; keep payloads small. Connections should be reused rather than reopened frequently.

--- a/docs/api/core_data_types.md
+++ b/docs/api/core_data_types.md
@@ -1,0 +1,26 @@
+# Core Data Types Module (`btol`)
+
+## Module Overview
+Defines the fundamental objects used throughout TOL. It targets language developers and advanced users needing to understand how values are represented.
+
+## Core Functions/Classes
+### `Matrix` / `VMatrix`
+Matrix representations; `VMatrix` is sparse. Constructors accept nested sets or arrays.
+
+### `Set`
+Unordered collection of items. Supports iteration and set algebra.
+
+### `NameBlock`
+Namespace-like structure containing variables and functions.
+
+## Data Types
+- `Real`, `Complex`, `Ratio`
+- `Text`, `Code`
+- `Polynomial`, `Matrix`, `VMatrix`
+- `Set`, `NameBlock`
+
+## Integration Notes
+All modules rely on these types. They are created in C++ but accessible from TOL scripts.
+
+## Performance Considerations
+Large matrices and sets allocate dynamic memory; sparse matrices (`VMatrix`) reduce storage for mostly zero data.

--- a/docs/api/database_connectivity.md
+++ b/docs/api/database_connectivity.md
@@ -1,0 +1,37 @@
+# Database Connectivity Module (`dbdrivers`)
+
+## Module Overview
+Provides drivers for interacting with relational databases through ODBC, MySQL, PostgreSQL and SQLite. Intended for users needing to load or store data persistently.
+
+## Core Functions/Classes
+### `DBOpen(Text dsn, Text user, Text pwd) -> Handle`
+Opens a connection to a database.
+- **Parameters**
+  - `dsn` – data source name or file path
+  - `user` – user name
+  - `pwd` – password
+- **Returns**: connection handle
+- **Errors**: raises `DBError` if connection fails.
+- **Example**
+```tol
+Handle h = DBOpen("mydb", "user", "secret");
+```
+
+### `DBExecQuery(Handle h, Text sql) -> Integer`
+Executes a statement that does not return rows.
+
+### `DBTable(Handle h, Text sql) -> Matrix`
+Executes a query and returns the result table.
+
+### `DBClose(Handle h)`
+Closes the connection.
+
+## Data Types
+- `Handle` – opaque connection context
+- result matrices contain rows as sets of basic types
+
+## Integration Notes
+Standard library modules can load these drivers dynamically. They rely on external DB client libraries.
+
+## Performance Considerations
+Fetching large result sets may require significant memory. Drivers stream rows when possible to reduce usage.

--- a/docs/api/file_system_integration.md
+++ b/docs/api/file_system_integration.md
@@ -1,0 +1,27 @@
+# File I/O and System Integration Module (`stdlib/system`)
+
+## Module Overview
+Supplies functions for reading/writing files, executing system commands and interacting with archives and network services via Curl.
+
+## Core Functions/Classes
+### `ReadFile(Text path) -> Text`
+Returns the contents of a text file.
+
+### `WriteFile(Text path, Text content)`
+Writes text to a file, creating or overwriting it.
+
+### `CurlGet(Text url) -> Text`
+Downloads content from an HTTP URL using `CurlApi`.
+
+### `PackArchive(Text srcDir, Text destFile)`
+Creates a compressed archive from a directory.
+
+## Data Types
+- file paths are plain `Text`
+- archive handles are returned as `Text` filenames
+
+## Integration Notes
+Used by build scripts and other modules that need filesystem access. Curl functions enable remote data retrieval.
+
+## Performance Considerations
+Large file operations allocate buffers proportional to file size. Network calls depend on external latency.

--- a/docs/api/gui_application.md
+++ b/docs/api/gui_application.md
@@ -1,0 +1,23 @@
+# GUI Application Module (`tolbase`)
+
+## Module Overview
+Tolbase is the graphical front end built with Tcl/Tk. It includes an editor, object browser and interactive console for running TOL code. Aimed at end users wanting a complete IDE.
+
+## Core Functions/Classes
+### `Tolbase::Start()`
+Initializes the Tcl/Tk environment and launches the main window.
+
+### `Tolbase::OpenFile(Text path)`
+Opens a `.tol` script in the editor.
+
+### `Tolbase::Eval(Text code)`
+Evaluates code in the embedded interpreter.
+
+## Data Types
+Uses standard Tcl/Tk widgets to manipulate text and windows.
+
+## Integration Notes
+The GUI can load plotting widgets from `tolbase` and invokes the core TOL interpreter underneath.
+
+## Performance Considerations
+Startup time depends on Tcl/Tk initialization. Heavy scripts run at native interpreter speed once loaded.

--- a/docs/api/gui_visualization.md
+++ b/docs/api/gui_visualization.md
@@ -1,0 +1,23 @@
+# GUI Visualization Module (`tolbase`)
+
+## Module Overview
+Provides graphical widgets for plotting sets and series using the BLT toolkit. Intended for interactive data exploration within Tolbase.
+
+## Core Functions/Classes
+### `SetGraph(Set data, Text title)`
+Displays multiple series contained in `data` on the same axes.
+
+### `SerGraph(Serie s, Text title)`
+Plots a single time series.
+
+### `Histogram(Matrix m, Integer bins)`
+Creates a histogram from matrix columns.
+
+## Data Types
+- `Set`, `Serie`, `Matrix`
+
+## Integration Notes
+These widgets are loaded by the Tolbase GUI and are used by the standard library plotting helpers.
+
+## Performance Considerations
+BLT rendering is efficient for moderate datasets. Extremely large sets may require thinning before display.

--- a/docs/api/java_api.md
+++ b/docs/api/java_api.md
@@ -1,0 +1,26 @@
+# Java API Module (`TolJava`)
+
+## Module Overview
+TolJava exposes TOL's functionality to Java programs via JNI. It provides a `TOLMachine` class that manages the interpreter and converts data between Java and TOL types.
+
+## Core Functions/Classes
+### `TOLMachine.start()`
+Loads the native library and creates an interpreter instance.
+
+### `TOLMachine.eval(String code) -> Object`
+Evaluates TOL code and converts the result to the closest Java type.
+
+### `TOLMachine.call(String name, Object... args) -> Object`
+Calls a TOL function by name with automatic type conversion.
+
+### `TOLMachine.shutdown()`
+Destroys the interpreter and unloads resources.
+
+## Data Types
+Java primitives and arrays map to TOL `Real`, `Text`, `Matrix`, `Serie` and others. Complex structures become `NameBlock` representations.
+
+## Integration Notes
+Used when embedding TOL in larger Java applications or web services. Requires the compiled native `tol` library in the system path.
+
+## Performance Considerations
+JNI calls introduce overhead; batch large operations when possible. Data conversion of big matrices may incur copy costs.

--- a/docs/api/mathematical_operations.md
+++ b/docs/api/mathematical_operations.md
@@ -1,0 +1,48 @@
+# Mathematical Operations Module (`bmath`)
+
+## Module Overview
+`bmath` provides TOL's low level numerical routines including arithmetic helpers, linear algebra wrappers and statistical utilities. It is aimed at users performing heavy mathematical computation or implementing high level algorithms.
+
+## Core Functions/Classes
+### `Add(Real a, Real b) -> Real`
+Adds two real numbers.
+- **Parameters**
+  - `a` – first operand
+  - `b` – second operand
+- **Returns**: result of `a + b`.
+- **Example**
+```tol
+Real x = Add(2, 3);  // 5
+```
+
+### `MatMul(Matrix A, Matrix B) -> Matrix`
+Multiplies matrices using BLAS/LAPACK routines.
+- **Parameters**
+  - `A` – left matrix; must have compatible dimensions
+  - `B` – right matrix
+- **Returns**: product matrix
+- **Errors**: raises `DimensionError` if shapes are incompatible.
+- **Example**
+```tol
+Matrix C = MatMul(A, B);
+```
+
+### `FFT(Set data) -> Set`
+Computes the discrete Fourier transform using FFTW.
+- **Parameters**
+  - `data` – set of real or complex values
+- **Returns**: transformed data
+- **Example**
+```tol
+Set freq = FFT(signal);
+```
+
+## Data Types
+- `Matrix`, `VMatrix` – dense and sparse matrices
+- `Real`, `Complex`, `Ratio`
+
+## Integration Notes
+`bmath` functions are used by higher level modules such as `bstat` and the standard library. They rely on external libraries like GSL and LAPACK.
+
+## Performance Considerations
+Matrix operations defer to optimized BLAS/LAPACK implementations. FFT uses FFTW for O(n log n) complexity.

--- a/docs/api/plotting_functions.md
+++ b/docs/api/plotting_functions.md
@@ -1,0 +1,27 @@
+# Core Plotting Functions Module (`stdlib/various/_plotter.tol`)
+
+## Module Overview
+Contains high level routines for generating charts and histograms. Targeted at users who need quick visualization from within TOL scripts.
+
+## Core Functions/Classes
+### `Plot(Code f, Real from, Real until, Real points) -> Set`
+Evaluates function `f` over the given range and returns a table of results. Also displays a chart.
+
+### `PlotSet(Set funcSet, Real from, Real until, Real points) -> Set`
+Plots multiple functions over the same domain.
+
+### `PlotMatrix(Matrix m)`
+Draws lines for each column of `m` against row index.
+
+### `SetHistConMult(Set dataSet, Set colS, Real bins) -> Set`
+Generates a multivariate histogram.
+
+## Data Types
+- input data as `Set` or `Matrix`
+- charts are displayed via the GUI subsystem but return tables for further use
+
+## Integration Notes
+These utilities rely on the plotting widgets provided by `tolbase`.
+
+## Performance Considerations
+For large matrices the plotting routines may perform aggregation to reduce rendering time.

--- a/docs/api/standard_library.md
+++ b/docs/api/standard_library.md
@@ -1,0 +1,26 @@
+# Standard Library Module (`stdlib`)
+
+## Module Overview
+Contains pure TOL functions packaged for general use: configuration handling, text utilities and numerical helpers. It is the first set of modules loaded when the interpreter starts.
+
+## Core Functions/Classes
+### `Include(Text module)`
+Loads a standard library module by name.
+
+### `TolConfigManager::Get(Text key) -> Text`
+Retrieves a configuration value.
+
+### `Split(Text str, Text sep) -> Set`
+Divides a string into a set of substrings.
+
+### `Map(Set s, Code f) -> Set`
+Applies function `f` to each element of `s`.
+
+## Data Types
+Mostly operates on built-in types such as `Set`, `Text` and numeric values.
+
+## Integration Notes
+Standard library modules depend on the core data types and may call into `bmath` or `bstat` for heavy computations.
+
+## Performance Considerations
+Functions are written in TOL, benefiting from lazy evaluation. Performance depends on the underlying native functions they call.

--- a/docs/api/statistical_analysis.md
+++ b/docs/api/statistical_analysis.md
@@ -1,0 +1,32 @@
+# Statistical Analysis Module (`bstat`)
+
+## Module Overview
+Implements modeling algorithms such as ARIMA, Bayesian Sparse Regression (BSR) and K-means clustering. Intended for statisticians and data scientists.
+
+## Core Functions/Classes
+### `ARIMA(Serie data, Set orders) -> NameBlock`
+Fits an ARIMA model.
+- **Parameters**
+  - `data` – input series
+  - `orders` – set `[p,d,q]` describing AR, differencing and MA orders
+- **Returns**: `NameBlock` containing fitted coefficients and diagnostics.
+- **Example**
+```tol
+NameBlock model = ARIMA(mySeries, [1,1,1]);
+```
+
+### `BSR(Matrix X, Serie y) -> NameBlock`
+Performs Bayesian Sparse Regression.
+
+### `KMeans(Matrix data, Integer k) -> Set`
+Clusters `data` into `k` groups.
+
+## Data Types
+- `Matrix`, `VMatrix`
+- `NameBlock` results with fields like `coeff`, `aic`, `residuals`
+
+## Integration Notes
+`bstat` depends on `bmath` for linear algebra and on time series utilities from `btol`.
+
+## Performance Considerations
+Algorithms may be computationally intensive; native implementations leverage optimized mathematical libraries.

--- a/docs/api/time_series_analysis.md
+++ b/docs/api/time_series_analysis.md
@@ -1,0 +1,37 @@
+# Time-Series Analysis Module (`btol`)
+
+## Module Overview
+Provides specialized operations for temporal data such as `Serie`, `TimeSet`, `Date` and `CTime`. Targeted at analysts manipulating chronological datasets.
+
+## Core Functions/Classes
+### `Lag(Serie s, Integer k) -> Serie`
+Returns a series shifted by `k` periods.
+- **Parameters**
+  - `s` – input series
+  - `k` – lag amount (positive or negative)
+- **Returns**: shifted series
+- **Example**
+```tol
+Serie y1 = Lag(y,1);
+```
+
+### `Resample(TimeSet ts, Text freq) -> TimeSet`
+Resamples a `TimeSet` to a new frequency (`"Monthly"`, `"Quarterly"`, etc.).
+- **Parameters**
+  - `ts` – original dataset
+  - `freq` – target granularity
+- **Returns**: resampled data
+
+### `DateAdd(Date d, Integer days) -> Date`
+Adds a number of days to a date.
+
+## Data Types
+- `Serie`
+- `TimeSet`
+- `Date`, `CTime`
+
+## Integration Notes
+Time series data feeds directly into statistical modeling modules like `bstat` and visualization components for plotting.
+
+## Performance Considerations
+Operations are implemented in native C++ for efficiency on large datasets.


### PR DESCRIPTION
## Summary
- document API for major TOL modules under `docs/api`
- reference the new docs in README

## Testing
- `python3 -m py_compile scripts/identify_pure_tol_files.py`
- `python3 scripts/identify_pure_tol_files.py > /dev/null`
- `tol-master/tol_tests/run_all_tests.sh` *(fails: /usr/local/tol-gcc-release/bin/tolcon not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6c6570d88327a2b942f8a9a8cc6d

## Summary by Sourcery

Add a comprehensive API reference under docs/api and link it from the main README.

Documentation:
- Introduce a docs/api directory containing Markdown reference guides for each major TOL module including mathematical operations, database connectivity, time-series and statistical analysis, core data types, file and system integration, plotting utilities, communication/remote access, the Java API, standard library, and GUI modules.
- Include a docs/api README listing all available module guides.
- Update the project README to reference the new API documentation directory.