### PR TITLE
docs: fix markdownlint warnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,12 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code)
+when working with code in this repository.
 
 ## Overview
 
-TOL (Time-Oriented Language) is a declarative, autoevaluative programming language with dynamic memory management and lazy evaluation, specifically designed for time-series analysis, mathematical computation, and statistical modeling. The codebase is primarily implemented in C++ with multiple build system support.
+TOL (Time-Oriented Language) is a declarative, autoevaluative programming language with dynamic memory management and lazy evaluation,
+specifically designed for time-series analysis, mathematical computation, and statistical modeling. The codebase is primarily implemented in C++ with multiple build system support.
 
 ## Current Project Status
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,20 +28,25 @@ By participating in this project, you agree to abide by our Code of Conduct:
 
 1. **Fork the repository** on GitHub
 2. **Clone your fork** locally:
+
    ```bash
    git clone https://github.com/YOUR-USERNAME/Tol.git
    cd Tol
-   ```
+```text
+
 3. **Add the upstream remote**:
+
    ```bash
    git remote add upstream https://github.com/InverenceBBS/Tol.git
-   ```
+```text
+
 4. **Keep your fork up to date**:
+
    ```bash
    git fetch upstream
    git checkout master
    git merge upstream/master
-   ```
+```text
 
 ## How to Contribute
 
@@ -89,7 +94,7 @@ cd tol-master
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Debug
 make -j$(nproc)
-```
+```text
 
 #### Using Autotools
 
@@ -98,7 +103,7 @@ cd tol-master/tol
 ./bootstrap
 ./configure --enable-debug
 make -j$(nproc)
-```
+```text
 
 ### Running Tests
 
@@ -109,7 +114,7 @@ make test
 # Or run the test suite directly
 cd ../tol_tests
 ./run_all_tests.sh
-```
+```text
 
 ## Coding Standards
 
@@ -130,6 +135,7 @@ cd ../tol_tests
   - One class per file when possible
 
 Example:
+
 ```cpp
 // tol_bmatrix.h
 #ifndef TOL_BMATRIX_H
@@ -150,7 +156,7 @@ public:
 };
 
 #endif // TOL_BMATRIX_H
-```
+```text
 
 ### TOL Language Style
 
@@ -159,6 +165,7 @@ public:
 - **Comments**: Use `//` for single-line, `/* */` for multi-line
 
 Example:
+
 ```tol
 // Calculate moving average of a time series
 Serie MovingAverage(Serie data, Real window) {
@@ -166,20 +173,20 @@ Serie MovingAverage(Serie data, Real window) {
   Serie result = Filter(data, weight * Ones(window));
   result
 };
-```
+```text
 
 ### Commit Messages
 
 Follow these guidelines for commit messages:
 
-- **Format**: 
-  ```
+- **Format**:
+```text
   <type>: <subject>
   
   <body>
   
   <footer>
-  ```
+```text
 
 - **Types**:
   - `feat`: New feature
@@ -197,7 +204,8 @@ Follow these guidelines for commit messages:
 - **Footer**: Reference issues (e.g., `Fixes #123`)
 
 Example:
-```
+
+```text
 feat: Add sparse matrix multiplication support
 
 Implement efficient sparse matrix multiplication using CHOLMOD
@@ -205,7 +213,7 @@ library. This improves performance for large sparse matrices
 commonly used in time series analysis.
 
 Fixes #456
-```
+```text
 
 ## Testing
 
@@ -216,6 +224,7 @@ Fixes #456
 - Use the test framework: `_tolTester.tol`
 
 Example test:
+
 ```tol
 // test_matrix_operations.tol
 Include("_tolTester.tol");
@@ -240,7 +249,7 @@ Set tests = [[
 Real RunTests(Real dummy) {
   Real TestGroup(testName, tests)
 };
-```
+```text
 
 ### Test Requirements
 
@@ -252,9 +261,10 @@ Real RunTests(Real dummy) {
 ## Pull Request Process
 
 1. **Create a feature branch**:
+
    ```bash
    git checkout -b feature/your-feature-name
-   ```
+```text
 
 2. **Make your changes**:
    - Write clean, well-documented code
@@ -262,20 +272,23 @@ Real RunTests(Real dummy) {
    - Update documentation as needed
 
 3. **Test your changes**:
+
    ```bash
    make test
-   ```
+```text
 
 4. **Commit your changes**:
+
    ```bash
    git add .
    git commit -m "feat: Add your feature description"
-   ```
+```text
 
 5. **Push to your fork**:
+
    ```bash
    git push origin feature/your-feature-name
-   ```
+```text
 
 6. **Create a Pull Request**:
    - Go to the original repository on GitHub
@@ -343,6 +356,7 @@ For feature requests, please:
 - **User documentation**: Clear, example-driven explanations
 
 Example documentation:
+
 ```cpp
 /**
  * Performs ARIMA model estimation on time series data
@@ -357,7 +371,7 @@ Example documentation:
  * @throws InsufficientDataException if series too short
  */
 ARIMAModel EstimateARIMA(const Serie& series, int p, int d, int q);
-```
+```text
 
 ### Areas Needing Documentation
 
@@ -384,6 +398,7 @@ ARIMAModel EstimateARIMA(const Serie& series, int p, int d, int q);
 ### Recognition
 
 Contributors are recognized in:
+
 - The AUTHORS file
 - Release notes
 - Project documentation

--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 # TOL - Time-Oriented Language
 
-TOL (Time-Oriented Language) is a powerful programming language specifically designed for time-series analysis, statistical modeling, and mathematical computations. Originally developed for advanced data analysis and econometric modeling, TOL provides a declarative environment that is autoevaluative (i.e., expressions are automatically evaluated as they are defined, similar to languages like Lisp), with dynamic memory management and lazy evaluation.
+TOL (Time-Oriented Language) is a powerful programming language specifically
+designed for time-series analysis, statistical modeling, and mathematical
+computations.
+Originally developed for advanced data analysis and econometric modeling,
+TOL provides a declarative environment that is autoevaluative (i.e.,
+expressions are automatically evaluated as they are defined,
+similar to languages like Lisp),
+with dynamic memory management and lazy evaluation.
 
 ## Overview
 
 TOL is a domain-specific language that excels in:
+
 - **Time-series analysis** with native support for temporal data structures
 - **Statistical modeling** including ARIMA, Bayesian methods, and Monte Carlo simulations
 - **Mathematical computations** with integrated linear algebra and numerical analysis
@@ -14,6 +22,7 @@ TOL is a domain-specific language that excels in:
 ## Key Features
 
 ### Language Characteristics
+
 - **Declarative paradigm** with functional programming elements
 - **Autoevaluative execution** with lazy evaluation
 - **Dynamic typing** with a strong type system
@@ -21,6 +30,7 @@ TOL is a domain-specific language that excels in:
 - **Integrated mathematical libraries** (GSL, LAPACK, BLAS, FFTW, CHOLMOD)
 
 ### Core Data Types
+
 - **Numerical:** `Real`, `Complex`, `Ratio` (rational numbers)
 - **Time-Related:** `Date`, `TimeSet`, `Serie` (time series), `CTime` (calendar time)
 - **Mathematical:** `Matrix`, `VMatrix` (sparse matrices), `Polynomial`, `PolMat` (polynomial matrices)
@@ -37,12 +47,14 @@ TOL is a domain-specific language that excels in:
 ## Installation
 
 ### From This GitHub Repository
+
 ```bash
 git clone https://github.com/m-marinucci/Tol.git
 cd Tol
 ```
 
 ### From Original GitLab Source
+
 ```bash
 git clone https://gitlab.com/tol-project/tol.git
 cd tol
@@ -51,6 +63,7 @@ cd tol
 ### Building from Source
 
 TOL has been successfully built and tested on:
+
 - ✅ Linux (x86_64, ARM64)
 - ✅ macOS (Intel, Apple Silicon)
 - ✅ Windows (MinGW, Visual Studio)
@@ -58,6 +71,7 @@ TOL has been successfully built and tested on:
 #### Prerequisites
 
 **Linux (Ubuntu/Debian):**
+
 ```bash
 sudo apt update
 sudo apt install -y build-essential cmake git \
@@ -66,6 +80,7 @@ sudo apt install -y build-essential cmake git \
 ```
 
 **macOS:**
+
 ```bash
 # Install Xcode Command Line Tools
 xcode-select --install
@@ -75,6 +90,7 @@ brew install cmake gsl lapack openblas fftw bzip2 suite-sparse
 ```
 
 **Windows:**
+
 - Install MinGW-w64 or Visual Studio 2019+
 - Install CMake
 - Dependencies can be installed via vcpkg or compiled manually
@@ -82,6 +98,7 @@ brew install cmake gsl lapack openblas fftw bzip2 suite-sparse
 #### Build Instructions
 
 **Linux/macOS:**
+
 ```bash
 cd tol-master/tol
 mkdir build && cd build
@@ -97,12 +114,14 @@ sudo make install
 ```
 
 **Windows (MinGW):**
+
 ```bash
 cd tol-master\building\MinGW
 build.bat
 ```
 
 **Windows (Visual Studio):**
+
 ```powershell
 cd tol-master\tol
 mkdir build
@@ -112,6 +131,7 @@ cmake --build . --config Release
 ```
 
 #### Using Autotools
+
 ```bash
 cd tol-master/tol
 ./bootstrap
@@ -121,7 +141,9 @@ sudo make install
 ```
 
 ### Dependencies
+
 To install common build dependencies (including LAPACK for linear algebra) on a fresh system, run:
+
 ```bash
 scripts/setup_build_env.sh
 ```
@@ -130,14 +152,17 @@ If the official TOL package repository is unavailable, download the default
 packages (StdLib and TclCore) using the helper script. It will query the
 Internet Archive's Wayback Machine API for the latest archived packages if the
 official server cannot be reached:
+
 ```bash
 scripts/fetch_default_packages.sh
 ```
+
 These packages contain the standard library and Tcl/Tk integration. Building
 without them removes many of TOL's mathematical functions, time series tools,
 and GUI features.
 
 TOL requires the following external libraries:
+
 - **GSL** (GNU Scientific Library) - Core mathematical functions
 - **FFTW** - Fast Fourier Transform operations
 - **CHOLMOD** - Sparse matrix operations
@@ -174,11 +199,13 @@ NameBlock Timer = [[
 ### Running TOL
 
 After installation, you can run TOL programs using:
+
 ```bash
 tolcon your_script.tol
 ```
 
 Or start an interactive session:
+
 ```bash
 tolcon
 ```
@@ -202,6 +229,7 @@ tolcon
 ## Contributing
 
 We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.md) for details on:
+
 - Code style and conventions
 - Testing requirements
 - Pull request process
@@ -209,7 +237,9 @@ We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.
 ## Future Developments
 
 ### TOL MCP Server
+
 We are developing an MCP (Model Context Protocol) server to provide seamless, natural language access to TOL's capabilities. This will enable:
+
 - Natural language queries for time-series analysis
 - Automated code generation from user intent
 - Integration with modern AI assistants
@@ -224,7 +254,9 @@ TOL is distributed under the terms specified in the [LICENSE](LICENSE) file.
 ## Documentation
 
 ### API Reference
+
 Comprehensive API documentation is available in the [`docs/api/`](docs/api/) directory:
+
 - **[Complete API Index](docs/api/README.md)** - Overview of all 12 TOL modules
 - **Core Computational**: Mathematical operations, statistical analysis, time-series processing
 - **Data Handling**: Database connectivity, file I/O, system integration
@@ -233,6 +265,7 @@ Comprehensive API documentation is available in the [`docs/api/`](docs/api/) dir
 - **MCP Compatible**: 8 modules support natural language interaction
 
 ### Documentation Features
+
 - **YAML Front-matter**: Machine-readable metadata for MCP server integration
 - **User Personas**: Content tailored for novices, experts, statisticians, and integrators
 - **Code Examples**: Tested TOL code samples with real-world use cases
@@ -247,5 +280,3 @@ Comprehensive API documentation is available in the [`docs/api/`](docs/api/) dir
 ## Acknowledgments
 
 TOL was originally developed by the Bayes Inference research group. Special thanks to all contributors who have helped make TOL a powerful tool for time-oriented programming and analysis.
-
-

--- a/docs/CONTRIBUTOR_GUIDELINES.md
+++ b/docs/CONTRIBUTOR_GUIDELINES.md
@@ -5,6 +5,7 @@ This document provides clear instructions for contributors working on TOL API do
 ## Overview
 
 The TOL API documentation follows a unified structure that combines:
+
 - **PR #14's approach**: User-friendly filenames and comprehensive organization
 - **PR #15's approach**: Detailed technical content and accurate module references
 - **YAML front-matter**: Machine-readable metadata for MCP server integration
@@ -14,11 +15,13 @@ The TOL API documentation follows a unified structure that combines:
 ### Option A: Sequential Merge (Recommended)
 
 **Step 1: Merge PR #14 First**
+
 1. PR #14 establishes the base structure in `docs/api/`
 2. Creates the main README.md index
 3. Sets the filename convention
 
 **Step 2: Rebase and Update PR #15**
+
 1. PR #15 author rebases onto merged PR #14
 2. Moves files from `docs/api_reference/` to `docs/api/`
 3. Renames files according to mapping table (see below)
@@ -28,6 +31,7 @@ The TOL API documentation follows a unified structure that combines:
 ### Option B: Consolidated Merge
 
 Create a new branch that manually combines both PRs:
+
 1. Clone repository and create `docs-consolidation` branch
 2. Manually merge content from both PRs
 3. Apply file naming mappings
@@ -113,19 +117,25 @@ Each documentation file should follow this structure:
 ```
 
 **Errors**
+
 - `ErrorType` if condition
 
 ## Data Types
+
 [List and describe relevant data types]
 
 ## Integration Notes
+
 [How this module works with other modules]
 
 ## Performance Considerations
+
 [Memory usage, computational complexity, optimization tips]
 
 ## Related Modules
+
 [Cross-references to related documentation]
+
 ```
 
 ## Step-by-Step Update Instructions
@@ -141,6 +151,7 @@ Each documentation file should follow this structure:
    ```
 
 3. **Move and rename files**:
+
    ```bash
    # Create the target directory structure
    mkdir -p docs/api
@@ -165,6 +176,7 @@ Each documentation file should follow this structure:
    - Maintain consistent formatting
 
 6. **Validate and test**:
+
    ```bash
    # Validate YAML front-matter
    python scripts/generate_api_index.py --validate-only
@@ -177,6 +189,7 @@ Each documentation file should follow this structure:
    ```
 
 7. **Update commit message and push**:
+
    ```bash
    git add docs/api/
    git commit -m "Merge API documentation: combine PR #14 structure with PR #15 content
@@ -195,10 +208,13 @@ Each documentation file should follow this structure:
 2. **Use the YAML template** from `docs/yaml_frontmatter_template.yaml`
 3. **Follow the content structure** outlined above
 4. **Test your documentation**:
+
    ```bash
    python scripts/generate_api_index.py --validate-only
    ```
+
 5. **Update the index**:
+
    ```bash
    python scripts/generate_api_index.py
    ```
@@ -224,6 +240,7 @@ Before submitting documentation:
 ## Automated Tools
 
 ### Index Generation
+
 ```bash
 # Generate/update the main README
 python scripts/generate_api_index.py
@@ -233,6 +250,7 @@ python scripts/generate_api_index.py --validate-only
 ```
 
 ### Markdown Linting
+
 ```bash
 # Fix common markdown issues
 npx markdownlint docs/api/*.md --fix
@@ -242,6 +260,7 @@ npx markdownlint docs/api/*.md
 ```
 
 ### YAML Validation
+
 The index generator automatically validates YAML front-matter and reports errors.
 
 ## Benefits for User Personas
@@ -257,6 +276,7 @@ This documentation structure serves multiple audiences:
 ## Support and Questions
 
 For questions about the documentation process:
+
 1. Check this guide first
 2. Review existing documentation examples
 3. Validate with automated tools
@@ -265,6 +285,7 @@ For questions about the documentation process:
 ## Future Enhancements
 
 Planned improvements to the documentation system:
+
 - Interactive code examples
 - Automated API extraction from C++ source
 - Documentation versioning


### PR DESCRIPTION
## Summary
- fix various markdownlint warnings across docs
- add blank lines around lists and code fences
- split some long lines for readability

## Testing
- `markdownlint README.md CLAUDE.md CONTRIBUTING.md docs/CONTRIBUTOR_GUIDELINES.md | head`

------
https://chatgpt.com/codex/tasks/task_b_687d71485ca08323b745701d4473acfe

## Summary by Sourcery

Fix markdownlint warnings and improve formatting in documentation

Documentation:
- Add blank lines around lists and code fences in CONTRIBUTING.md, README.md, docs/CONTRIBUTOR_GUIDELINES.md, and CLAUDE.md
- Split overly long lines in multiple markdown files for better readability
- Standardize code fence language to 'text' for consistent markdown rendering