### PR TITLE
Remove broken MCP plan link

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ We are developing an MCP (Model Context Protocol) server to provide seamless, na
 - Integration with modern AI assistants
 - Simplified access to TOL's powerful features
 
-See [TOL_MCP_SERVER_STRATEGIC_PLAN.md](TOL_MCP_SERVER_STRATEGIC_PLAN.md) for details.
+The strategic plan for the MCP server is under development and will be added here once available.
 
 ## License
 


### PR DESCRIPTION
## Summary
- fix the `Future Developments` section of the README
- remove link to missing `TOL_MCP_SERVER_STRATEGIC_PLAN.md`
- mention that the plan will be added later

## Testing
- `grep -o "(.*\.md)" -n README.md`

------
https://chatgpt.com/codex/tasks/task_b_687d70b3b89883238f7f448c15ba7a41

## Summary by Sourcery

Documentation:
- Remove broken link to TOL_MCP_SERVER_STRATEGIC_PLAN.md and add placeholder text noting the strategic plan will be added later.