### PR TITLE
Remove broken link to strategic plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ We are developing an MCP (Model Context Protocol) server to provide seamless, na
 - Integration with modern AI assistants
 - Simplified access to TOL's powerful features
 
-See [TOL_MCP_SERVER_STRATEGIC_PLAN.md](TOL_MCP_SERVER_STRATEGIC_PLAN.md) for details.
+The strategic plan for the MCP server is under development and will be added here once available.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Removes broken link to strategic plan from README.md
- The link was returning 404 and no replacement URL was available

## Test plan
- [x] Verify README.md renders correctly
- [x] No broken links remain

🤖 Generated with [Claude Code](https://claude.ai/code)